### PR TITLE
Require user and password for couch

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -29,6 +29,5 @@ jobs:
       run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb@localhost/_config/native_query_servers/enable_erlang_query_server'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,14 +13,14 @@ jobs:
       matrix:
         couchdb: ["3.3", "3.2", "3.1", "2.3"]
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v4
     - name: Set up CouchDB
       uses: ./
       with:
         couchdb version: ${{ matrix.couchdb }}
       env:
         COUCHDB_USER: admin
-        COUCHDB_PASSOWRD: password
+        COUCHDB_PASSWORD: password
     - name: Test that CouchDB can be accessed
       run: curl -sS -f http://admin:password@localhost:5984/
     - name: Test that system databases are there

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,17 +9,23 @@ on:
 jobs:
   tests:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        couchdb: ["3.3", "3.2", "3.1", "2.3"]
     steps:
     - uses: actions/checkout@v1
     - name: Set up CouchDB
       uses: ./
       with:
-        couchdb version: '2.3.1'
+        couchdb version: ${{ matrix.couchdb }}
+      env:
+        COUCHDB_USERNAME: admin
+        COUCHDB_PASSOWRD: password
     - name: Test that CouchDB can be accessed
-      run: curl -sS -f http://127.0.0.1:5984/
+      run: curl -sS -f http://admin:password@127.0.0.1:5984/
     - name: Test that system databases are there
-      run: curl -sS -f http://127.0.0.1:5984/_users
+      run: curl -sS -f http://admin:password@127.0.0.1:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -sS -f 'http://127.0.0.1:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
-        curl -sS -f 'http://127.0.0.1:5984/_users/_design/test/_view/test'
+        curl -sS -f 'http://admin:password@127.0.0.1:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
+        curl -sS -f 'http://admin:password@127.0.0.1:5984/_users/_design/test/_view/test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -20,6 +20,7 @@ jobs:
         couchdb version: ${{ matrix.couchdb }}
       env:
         NODENAME: localhost
+        ERL_NATOVE_QUERY: true
         COUCHDB_USER: admin
         COUCHDB_PASSWORD: password
     - name: Test that CouchDB can be accessed

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       with:
         couchdb version: ${{ matrix.couchdb }}
       env:
-        COUCHDB_USERNAME: admin
+        COUCHDB_USER: admin
         COUCHDB_PASSOWRD: password
     - name: Test that CouchDB can be accessed
       run: curl -sS -f http://admin:password@127.0.0.1:5984/

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,5 +27,6 @@ jobs:
       run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
+        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb2@localhost/_config/native_query_servers/enable_erlang_query_server'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,6 +19,7 @@ jobs:
       with:
         couchdb version: ${{ matrix.couchdb }}
       env:
+        NODENAME: localhost
         COUCHDB_USER: admin
         COUCHDB_PASSWORD: password
     - name: Test that CouchDB can be accessed
@@ -27,6 +28,6 @@ jobs:
       run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb@localhost/_config/native_query_servers/enable_erlang_query_server'
+        curl -X GET 'http://admin:password@localhost:5984/_membership'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,10 +22,10 @@ jobs:
         COUCHDB_USER: admin
         COUCHDB_PASSOWRD: password
     - name: Test that CouchDB can be accessed
-      run: curl -sS -f http://admin:password@127.0.0.1:5984/
+      run: curl -sS -f http://admin:password@localhost:5984/
     - name: Test that system databases are there
-      run: curl -sS -f http://admin:password@127.0.0.1:5984/_users
+      run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -sS -f 'http://admin:password@127.0.0.1:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
-        curl -sS -f 'http://admin:password@127.0.0.1:5984/_users/_design/test/_view/test'
+        curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
+        curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,4 +28,4 @@ jobs:
     - name: Test that the Erlang query server is enabled
       run: |
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
-        curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test'
+        curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -27,6 +27,6 @@ jobs:
       run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb2@localhost/_config/native_query_servers/enable_erlang_query_server'
+        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb@localhost/_config/native_query_servers/enable_erlang_query_server'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,6 +28,6 @@ jobs:
       run: curl -sS -f http://admin:password@localhost:5984/_users
     - name: Test that the Erlang query server is enabled
       run: |
-        curl -X GET 'http://admin:password@localhost:5984/_membership'
+        curl -X GET 'http://admin:password@localhost:5984/_node/couchdb@localhost/_config/native_query_servers/enable_erlang_query_server'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test' -X PUT -H 'Content-Type: application/json' --data '{"views":{"test":{"map":"fun({Doc}) -> Emit(proplists:get_value(<<\"name\">>, Doc, null), 1) end."}},"language":"erlang"}'
         curl -sS -f 'http://admin:password@localhost:5984/_users/_design/test/_view/test' -v

--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ steps:
     uses: "cobot/couchdb-action@master"
     with:
       couchdb version: '2.3.1'
+    env:
+      COUCHDB_USER: admin
+      COUCHDB_PASSWORD: password
   - name: Do something
     run: |
       curl http://127.0.0.1:5984/

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,6 +2,7 @@
 
 echo "Starting Docker..."
 ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
+NODENAME="${NODENAME}:-localhost"
 
 sh -c "docker run -d -p 5984:5984 -p 5986:5986 -e \"NODENAME=${NODENAME}\" -e \"COUCHDB_USER=${COUCHDB_USER}\" -e \"COUCHDB_PASSWORD=${COUCHDB_PASSWORD}\" --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,7 +2,7 @@
 
 echo "Starting Docker..."
 ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
-NODENAME="${NODENAME}:-localhost"
+NODENAME="${NODENAME:-localhost}"
 
 sh -c "docker run -d -p 5984:5984 -p 5986:5986 -e \"NODENAME=${NODENAME}\" -e \"COUCHDB_USER=${COUCHDB_USER}\" -e \"COUCHDB_PASSWORD=${COUCHDB_PASSWORD}\" --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,15 +1,14 @@
 #!/bin/sh
 
 echo "Starting Docker..."
-
 ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
 
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 NODENAME=$NODENAME COUCHDB_USER=$COUCHDB_USER COUCHDB_PASSWORD=$COUCHDB_PASSWORD --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 NODENAME=${NODENAME} COUCHDB_USER=${COUCHDB_USER} COUCHDB_PASSWORD=${COUCHDB_PASSWORD} --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
 
-docker exec $NAME sh -c 'mkdir -p /opt/couchdb/etc/local.d && echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nenable_erlang_query_server=$ERL_QUERIES" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
+docker exec $NAME sh -c "mkdir -p /opt/couchdb/etc/local.d && echo \"[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nenable_erlang_query_server=${ERL_QUERIES}\" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini"
 
 wait_for_couchdb() {
   echo "Waiting for CouchDB..."
@@ -25,6 +24,6 @@ wait_for_couchdb
 
 # Set up system databases
 echo "Setting up CouchDB system databases..."
-docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_users" -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
-docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_global_changes" -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
-docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_replicator" -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null
+docker exec $NAME curl -sS "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_users" -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
+docker exec $NAME curl -sS "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_global_changes" -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
+docker exec $NAME curl -sS "http://${COUCHDB_USER}:${COUCHDB_PASSWORD}@localhost:5984/_replicator" -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -4,7 +4,7 @@ echo "Starting Docker..."
 
 ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
 
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 COUCHDB_USER=$COUCHDB_USER COUCHDB_PASSWORD=$COUCHDB_PASSWORD --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 NODENAME=$NODENAME COUCHDB_USER=$COUCHDB_USER COUCHDB_PASSWORD=$COUCHDB_PASSWORD --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 echo "Starting Docker..."
-ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
+ERL_QUERIES="${ERL_NATIVE_QUERY:-true}"
 NODENAME="${NODENAME:-localhost}"
 
 sh -c "docker run -d -p 5984:5984 -p 5986:5986 -e \"NODENAME=${NODENAME}\" -e \"COUCHDB_USER=${COUCHDB_USER}\" -e \"COUCHDB_PASSWORD=${COUCHDB_PASSWORD}\" --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,7 +1,8 @@
 #!/bin/sh
 
 echo "Starting Docker..."
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
+
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 COUCHDB_USER=$COUCHDB_USER COUCHDB_PASSWORD=$COUCHDB_PASSWORD --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -2,12 +2,14 @@
 
 echo "Starting Docker..."
 
+ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
+
 sh -c "docker run -d -p 5984:5984 -p 5986:5986 COUCHDB_USER=$COUCHDB_USER COUCHDB_PASSWORD=$COUCHDB_PASSWORD --tmpfs /ram_disk couchdb:$INPUT_COUCHDB_VERSION"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`
 
-docker exec $NAME sh -c 'mkdir -p /opt/couchdb/etc/local.d && echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nerlang = {couch_native_process, start_link, []}" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
+docker exec $NAME sh -c 'mkdir -p /opt/couchdb/etc/local.d && echo "[couchdb]\ndatabase_dir = /ram_disk\nview_index_dir = /ram_disk\ndelayed_commits = true\n[httpd]\nsocket_options = [{nodelay, true}]\n[native_query_servers]\nenable_erlang_query_server=$ERL_QUERIES" >> /opt/couchdb/etc/local.d/01-github-action-custom.ini'
 
 wait_for_couchdb() {
   echo "Waiting for CouchDB..."
@@ -23,6 +25,6 @@ wait_for_couchdb
 
 # Set up system databases
 echo "Setting up CouchDB system databases..."
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_users' -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_global_changes' -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
-docker exec $NAME curl -sS 'http://127.0.0.1:5984/_replicator' -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null
+docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_users" -X PUT -H 'Content-Type: application/json' --data '{"id":"_users","name":"_users"}' > /dev/null
+docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_global_changes" -X PUT -H 'Content-Type: application/json' --data '{"id":"_global_changes","name":"_global_changes"}' > /dev/null
+docker exec $NAME curl -sS "http://$COUCHDB_USER:$COUCHDB_PASSWORD@localhost:5984/_replicator" -X PUT -H 'Content-Type: application/json' --data '{"id":"_replicator","name":"_replicator"}' > /dev/null

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -3,7 +3,7 @@
 echo "Starting Docker..."
 ERL_QUERIES="${ERL_NATIVE_QUERY:-false}"
 
-sh -c "docker run -d -p 5984:5984 -p 5986:5986 NODENAME=${NODENAME} COUCHDB_USER=${COUCHDB_USER} COUCHDB_PASSWORD=${COUCHDB_PASSWORD} --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"
+sh -c "docker run -d -p 5984:5984 -p 5986:5986 -e \"NODENAME=${NODENAME}\" -e \"COUCHDB_USER=${COUCHDB_USER}\" -e \"COUCHDB_PASSWORD=${COUCHDB_PASSWORD}\" --tmpfs /ram_disk couchdb:${INPUT_COUCHDB_VERSION}"
 
 # CouchDB container name
 export NAME=`docker ps --format "{{.Names}}" --last 1`


### PR DESCRIPTION
Newer versions of Couch requires user/password to be set. This PR will make it mandatory, I am not sure if this will work on couch < 2.0, But on our use case we need to support newer versions and allow Erlang native queries